### PR TITLE
address crash on Catalina using Python 3.7

### DIFF
--- a/pyobjc-core/Modules/objc/method-signature.m
+++ b/pyobjc-core/Modules/objc/method-signature.m
@@ -577,7 +577,10 @@ setup_descr(struct _PyObjC_ArgDescr* descr, PyObject* meta, BOOL is_native)
         } else {
             if (descr == NULL || (descr->tmpl && descr->alreadyRetained))
                 return -2;
-            descr->alreadyRetained = NO;
+            // descr may be loaded into read-only memory, so only
+            // write if truly necessary
+            if (descr->alreadyRetained)
+                descr->alreadyRetained = NO;
         }
     }
 


### PR DESCRIPTION
This occurs when PyObjC is built with `MACOSX_DEPLOYMENT_TARGET=10.15`. `setup_descr` writes to a location that's read-only, but AFAICT this particular write is redundant.

fixes #265

Repost of a [PR23](https://bitbucket.org/ronaldoussoren/pyobjc/pull-requests/23) on BitBucket.