### PR TITLE
pyobjc_setup.py: sdk detection fixes

### DIFF
--- a/pyobjc-core/Tools/pyobjc_setup.py
+++ b/pyobjc-core/Tools/pyobjc_setup.py
@@ -203,23 +203,44 @@ def get_os_level():
     return ".".join(v.split(".")[:2])
 
 
-def get_sdk_level():
-    cflags = get_config_var("CFLAGS")
-    cflags = shlex.split(cflags)
-    for i, val in enumerate(cflags):
-        if val == "-isysroot":
-            sdk = cflags[i + 1]
+def get_sdk():
+    env_cflags = os.environ.get("CFLAGS", "")
+    config_cflags = get_config_var("CFLAGS")
+    sdk = None
+    for cflags_str in [env_cflags, config_cflags]:
+        cflags = shlex.split(cflags_str)
+        for i, val in enumerate(cflags):
+            if val == "-isysroot":
+                sdk = cflags[i + 1]
+                break
+            elif val.find("-isysroot") == 0:
+                sdk = val[len("-isysroot"):]
+                break
+        if sdk:
             break
-    else:
+
+    return sdk
+
+def get_sdk_level():
+    sdk = get_sdk()
+
+    if not sdk:
         return None
 
     if sdk == "/":
         return get_os_level()
 
-    sdk = os.path.basename(sdk)
-    assert sdk.startswith("MacOSX")
-    assert sdk.endswith(".sdk")
-    return sdk[6:-4]
+    sdkname = os.path.basename(sdk)
+    assert sdkname.startswith("MacOSX")
+    assert sdkname.endswith(".sdk")
+    if sdkname == "MacOSX.sdk":
+        try:
+            pl = plistlib.readPlist(os.path.join(sdk, "SDKSettings.plist"))
+            return pl["Version"]
+        except:
+            raise SystemExit("Cannot determine SDK version")
+    else:
+        return sdkname[6:-4]
 
 
 class pyobjc_install_lib(install_lib.install_lib):
@@ -394,15 +415,14 @@ def Extension(*args, **kwds):
     if "clang" in get_config_var("CC"):
         cflags.append("-Wno-deprecated-declarations")
 
-    CFLAGS = get_config_var("CFLAGS")
-    if "-isysroot" not in CFLAGS:  # and os.path.exists('/usr/include/stdio.h'):
-        # We're likely on a system with de Xcode Command Line Tools.
-        # Explicitly use the most recent problems to avoid compile problems.
+    sdk = get_sdk()
+    if not sdk: # and os.path.exists('/usr/include/stdio.h'):
+        # We're likely on a system with the Xcode Command Line Tools.
+        # Explicitly use the most recent SDK to avoid compile problems.
         data = subprocess.check_output(
             ["/usr/bin/xcrun", "-sdk", "macosx", "--show-sdk-path"],
             universal_newlines=True,
         ).strip()
-        data = data.strip()
         if data:
             cflags.append("-isysroot")
             cflags.append(data)


### PR DESCRIPTION
Detect correct SDK when an `-isysroot` flag is given in `CFLAGS` in the environment, overriding any that may be in sysconfig. Support alternate form of `-isysroot` where there is no space between the flag and the associated path. Don't try to extract a version from the filename of `MacOSX.sdk`; instead get the version from its SDKSettings.plist.

This is a repost of [PR22](https://bitbucket.org/ronaldoussoren/pyobjc/pull-requests/22) from BitBucket by @jmroot, collapsed into a single commit.