### PR TITLE
misc arm64 Mac OS 11 fixes

### DIFF
--- a/pyobjc-core/Lib/objc/_dyld.py
+++ b/pyobjc-core/Lib/objc/_dyld.py
@@ -13,6 +13,7 @@ __all__ = [
 import os
 
 from objc._framework import infoForFramework
+
 try:
     from objc._objc import _dyld_shared_cache_contains_path
 except ImportError:

--- a/pyobjc-core/Modules/objc/libffi_support.m
+++ b/pyobjc-core/Modules/objc/libffi_support.m
@@ -4408,7 +4408,11 @@ PyObjCFFI_MakeClosure(PyObjCMethodSignature* methinfo, PyObjCFFI_ClosureFunc fun
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+        #if __arm64__
+        __builtin_unreachable();
+        #else
         rv = ffi_prep_closure(cl, cif, func, userdata);
+        #endif
 
 #pragma clang diagnostic pop
     }

--- a/pyobjc-core/Modules/objc/module.m
+++ b/pyobjc-core/Modules/objc/module.m
@@ -37,7 +37,7 @@ static NSAutoreleasePool* global_release_pool = nil;
 /* There is no public API for checking if a library is in the
  * shared library cache.
  */
-extern int _dyld_shared_cache_contains_path(const char* path) 
+extern int _dyld_shared_cache_contains_path(const char* path)
     __attribute__((availability(macos, introduced=10.16)));
 #endif
 

--- a/pyobjc-core/Modules/objc/module.m
+++ b/pyobjc-core/Modules/objc/module.m
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <sys/socket.h>
 
+#import <AvailabilityVersions.h>
 #import <Foundation/NSAutoreleasePool.h>
 #import <Foundation/NSBundle.h>
 #import <Foundation/NSProcessInfo.h>
@@ -2756,12 +2757,12 @@ PyObject* __attribute__((__visibility__("default"))) PyInit__objc(void)
     }
 #endif /* MAC_OS_X_VERSION_10_16 */
 
-#ifdef MAC_OS_X_VERSION_11_0
-    if (PyModule_AddIntConstant(m, "MAC_OS_X_VERSION_11_0", MAC_OS_X_VERSION_11_0)
+#ifdef MAC_OS_VERSION_11_0
+    if (PyModule_AddIntConstant(m, "MAC_OS_VERSION_11_0", MAC_OS_VERSION_11_0)
         < 0) {
         return NULL;
     }
-#endif /* MAC_OS_X_VERSION_11_0 */
+#endif /* MAC_OS_VERSION_11_0 */
 
     if (PyModule_AddIntConstant(m, "PyObjC_BUILD_RELEASE", PyObjC_BUILD_RELEASE) < 0) {
         return NULL;

--- a/pyobjc-core/Modules/objc/opaque-pointer.m
+++ b/pyobjc-core/Modules/objc/opaque-pointer.m
@@ -368,7 +368,11 @@ PyObjCCreateOpaquePointerType(const char* name, const char* typestr, const char*
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+        #if __arm64__
+        __builtin_unreachable();
+        #else
         rv = ffi_prep_closure(cl_to_c, convert_cif, opaque_to_c, newType);
+        #endif
 
 #pragma clang diagnostic pop
     }
@@ -399,7 +403,11 @@ PyObjCCreateOpaquePointerType(const char* name, const char* typestr, const char*
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+        #if __arm64__
+        __builtin_unreachable();
+        #else
         rv = ffi_prep_closure(cl_from_c, new_cif, opaque_from_c, newType);
+        #endif
 
 #pragma clang diagnostic pop
     }

--- a/pyobjc-core/Modules/objc/struct-wrapper.m
+++ b/pyobjc-core/Modules/objc/struct-wrapper.m
@@ -929,7 +929,11 @@ make_init(const char* typestr)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
+        #if __arm64__
+        __builtin_unreachable();
+        #else
         rv = ffi_prep_closure(cl, init_cif, struct_init, (char*)typestr);
+        #endif
 
 #pragma clang diagnostic pop
     }

--- a/pyobjc-core/PyObjCTest/test_archive_python.py
+++ b/pyobjc-core/PyObjCTest/test_archive_python.py
@@ -1040,6 +1040,10 @@ class TestKeyedArchivePlainPython(TestCase, test.pickletester.AbstractPickleTest
     def test_complex_newobj_ex(self):
         pass
 
+    @onlyIf(0, "python unittest not relevant for archiving")
+    def test_buffers_numpy(self):
+        pass
+
     @expectedFailure
     def test_newobj_not_class(self):
         # Exception handling in NSCoder is dodgy

--- a/pyobjc-core/PyObjCTest/test_constants.py
+++ b/pyobjc-core/PyObjCTest/test_constants.py
@@ -6,8 +6,11 @@ class TestConstants(TestCase):
     def test_version_current(self):
         self.assertIsInstance(objc.MAC_OS_X_VERSION_CURRENT, int)
 
-        v = os_release().split(".")[:2]
-        v = "MAC_OS_X_VERSION_%s_%s" % tuple(v)
+        v = tuple(map(int, os_release().split(".")[:2]))
+        if v < (11,):
+            v = "MAC_OS_X_VERSION_%d_%d" % v
+        else:
+            v = "MAC_OS_VERSION_%d_%d" % v
 
         self.assertGreaterEqual(objc.MAC_OS_X_VERSION_CURRENT, getattr(objc, v))
 
@@ -41,3 +44,4 @@ class TestConstants(TestCase):
         self.assertEqual(objc.MAC_OS_X_VERSION_10_13_6, 101_306)
         self.assertEqual(objc.MAC_OS_X_VERSION_10_14, 101_400)
         self.assertEqual(objc.MAC_OS_X_VERSION_10_14_1, 101_401)
+        self.assertEqual(objc.MAC_OS_VERSION_11_0, 110_000)

--- a/pyobjc-core/PyObjCTest/test_dyld.py
+++ b/pyobjc-core/PyObjCTest/test_dyld.py
@@ -75,7 +75,9 @@ class TestDyld(TestCase):
 
             lst = []
             with self.assertRaises(ValueError):
-                result = dyld.dyld_library("/usr/lib/libSystem.dylib", "libXSystem.dylib")
+                result = dyld.dyld_library(
+                    "/usr/lib/libSystem.dylib", "libXSystem.dylib"
+                )
                 print("Found", result)
             self.assertEqual(
                 lst,
@@ -186,7 +188,9 @@ class TestDyld(TestCase):
 
         finally:
             os.path.exists = orig_exists
-            dyld._dyld_shared_cache_contains_path = orig__dyld_shared_cache_contains_path
+            dyld._dyld_shared_cache_contains_path = (
+                orig__dyld_shared_cache_contains_path
+            )
 
         self.assertEqual(
             dyld.dyld_library("/usr/lib/libSystem.dylib", "libXSystem.dylib"),

--- a/pyobjc-core/setup.py
+++ b/pyobjc-core/setup.py
@@ -167,9 +167,17 @@ class oc_build_py(build_py.build_py):
 
 class oc_test(test.test):
     description = "run test suite"
-    user_options = [("verbosity=", None, "print what tests are run")]
+    user_options = [
+        ("verbosity=", None, "print what tests are run"),
+        (
+            "xml=",
+            None,
+            "xml output filename (requires: pip install unittest-xml-reporting)",
+        ),
+    ]
 
     def initialize_options(self):
+        self.xml = None
         self.verbosity = "1"
 
     def finalize_options(self):
@@ -256,8 +264,15 @@ class oc_test(test.test):
         try:
             suite = makeTestSuite()
 
-            runner = unittest.TextTestRunner(verbosity=self.verbosity)
-            result = runner.run(suite)
+            if self.xml:
+                with open(self.xml, "wb") as out:
+                    import xmlrunner
+
+                    runner = xmlrunner.XMLTestRunner(output=out)
+                    result = runner.run(suite)
+            else:
+                runner = unittest.TextTestRunner(verbosity=self.verbosity)
+                result = runner.run(suite)
 
             # Print out summary. This is a structured format that
             # should make it easy to use this information in scripts.

--- a/pyobjc-framework-SystemConfiguration/PyObjCTest/test_scnetworkconfiguration.py
+++ b/pyobjc-framework-SystemConfiguration/PyObjCTest/test_scnetworkconfiguration.py
@@ -174,7 +174,12 @@ class TestSCNetworkConfiguration(TestCase):
         )
         self.assertTrue(r is True or r is False)
 
-        r, current, active, available = SystemConfiguration.SCNetworkInterfaceCopyMediaOptions(
+        (
+            r,
+            current,
+            active,
+            available,
+        ) = SystemConfiguration.SCNetworkInterfaceCopyMediaOptions(
             iface, None, None, None, False
         )
         self.assertTrue(r is True)

--- a/pyobjc-framework-SystemConfiguration/PyObjCTest/test_scnetworkconnection.py
+++ b/pyobjc-framework-SystemConfiguration/PyObjCTest/test_scnetworkconnection.py
@@ -70,9 +70,11 @@ class TestSCNetworkConnection(TestCase):
         self.assertArgIsOut(
             SystemConfiguration.SCNetworkConnectionCopyUserPreferences, 2
         )
-        v, servId, userOpts = SystemConfiguration.SCNetworkConnectionCopyUserPreferences(
-            None, None, None
-        )
+        (
+            v,
+            servId,
+            userOpts,
+        ) = SystemConfiguration.SCNetworkConnectionCopyUserPreferences(None, None, None)
         if v:
             self.assertIsInstance(servId, str)
             self.assertIsInstance(


### PR DESCRIPTION
I (finally) deconflicted my own branch for Mac OS 11 and arm64 with `pyobjc-7-branch`.   It turns out most of it is stuff you've already covered.    Here's a few things that are left over.

