### PR TITLE
Update AppHelper.py

### DIFF
--- a/pyobjc-framework-Cocoa/Lib/PyObjCTools/AppHelper.py
+++ b/pyobjc-framework-Cocoa/Lib/PyObjCTools/AppHelper.py
@@ -258,7 +258,7 @@ def runConsoleEventLoop(
                 break
 
             soon = NSDate.dateWithTimeIntervalSinceNow_(maxTimeout)
-            nextfire = nextfire.earlierDate_(soon)
+            nextfire = soon.earlierDate_(nextfire)
             if not runLoop.runMode_beforeDate_(mode, nextfire):
                 stopper.stop()
 


### PR DESCRIPTION
Switching variables 'nextfire' and 'soon' in the 'earlierDate()' call of 'runConsoleEventLoop'
'nextfire' can be instantiated as 'nil' which then leads to a runtime error ('NoneType' object has no attribute 'earlierDate_'). 
'soon' is always instantiated as NSDate object, so the 'earlierDate()' method is always available.