### PR TITLE
Make SDK detection tolerate trailing slashes

### DIFF
--- a/pyobjc-core/Tools/pyobjc_setup.py
+++ b/pyobjc-core/Tools/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AVFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-AVFoundation/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AVKit/pyobjc_setup.py
+++ b/pyobjc-framework-AVKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Accounts/pyobjc_setup.py
+++ b/pyobjc-framework-Accounts/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AdSupport/pyobjc_setup.py
+++ b/pyobjc-framework-AdSupport/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AddressBook/pyobjc_setup.py
+++ b/pyobjc-framework-AddressBook/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ApplicationServices/pyobjc_setup.py
+++ b/pyobjc-framework-ApplicationServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
+++ b/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Automator/pyobjc_setup.py
+++ b/pyobjc-framework-Automator/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-BusinessChat/pyobjc_setup.py
+++ b/pyobjc-framework-BusinessChat/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CFNetwork/pyobjc_setup.py
+++ b/pyobjc-framework-CFNetwork/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CalendarStore/pyobjc_setup.py
+++ b/pyobjc-framework-CalendarStore/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CloudKit/pyobjc_setup.py
+++ b/pyobjc-framework-CloudKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Cocoa/pyobjc_setup.py
+++ b/pyobjc-framework-Cocoa/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Collaboration/pyobjc_setup.py
+++ b/pyobjc-framework-Collaboration/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ColorSync/pyobjc_setup.py
+++ b/pyobjc-framework-ColorSync/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Contacts/pyobjc_setup.py
+++ b/pyobjc-framework-Contacts/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ContactsUI/pyobjc_setup.py
+++ b/pyobjc-framework-ContactsUI/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreAudio/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudio/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
+++ b/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreData/pyobjc_setup.py
+++ b/pyobjc-framework-CoreData/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreHaptics/pyobjc_setup.py
+++ b/pyobjc-framework-CoreHaptics/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreLocation/pyobjc_setup.py
+++ b/pyobjc-framework-CoreLocation/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreML/pyobjc_setup.py
+++ b/pyobjc-framework-CoreML/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreMedia/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMedia/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreMotion/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMotion/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreServices/pyobjc_setup.py
+++ b/pyobjc-framework-CoreServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
+++ b/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreText/pyobjc_setup.py
+++ b/pyobjc-framework-CoreText/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CoreWLAN/pyobjc_setup.py
+++ b/pyobjc-framework-CoreWLAN/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
+++ b/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DVDPlayback/pyobjc_setup.py
+++ b/pyobjc-framework-DVDPlayback/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DeviceCheck/pyobjc_setup.py
+++ b/pyobjc-framework-DeviceCheck/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DictionaryServices/pyobjc_setup.py
+++ b/pyobjc-framework-DictionaryServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DiscRecording/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecording/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-DiskArbitration/pyobjc_setup.py
+++ b/pyobjc-framework-DiskArbitration/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-EventKit/pyobjc_setup.py
+++ b/pyobjc-framework-EventKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
+++ b/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
+++ b/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
+++ b/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-FSEvents/pyobjc_setup.py
+++ b/pyobjc-framework-FSEvents/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-FileProvider/pyobjc_setup.py
+++ b/pyobjc-framework-FileProvider/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-FileProviderUI/pyobjc_setup.py
+++ b/pyobjc-framework-FileProviderUI/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-FinderSync/pyobjc_setup.py
+++ b/pyobjc-framework-FinderSync/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-GameCenter/pyobjc_setup.py
+++ b/pyobjc-framework-GameCenter/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-GameController/pyobjc_setup.py
+++ b/pyobjc-framework-GameController/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-GameKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-GameplayKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameplayKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
+++ b/pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-IOSurface/pyobjc_setup.py
+++ b/pyobjc-framework-IOSurface/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
+++ b/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-InputMethodKit/pyobjc_setup.py
+++ b/pyobjc-framework-InputMethodKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
+++ b/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-InstantMessage/pyobjc_setup.py
+++ b/pyobjc-framework-InstantMessage/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Intents/pyobjc_setup.py
+++ b/pyobjc-framework-Intents/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
+++ b/pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
+++ b/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-LaunchServices/pyobjc_setup.py
+++ b/pyobjc-framework-LaunchServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-LinkPresentation/pyobjc_setup.py
+++ b/pyobjc-framework-LinkPresentation/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
+++ b/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MapKit/pyobjc_setup.py
+++ b/pyobjc-framework-MapKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
+++ b/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MediaLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-MediaLibrary/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MediaPlayer/pyobjc_setup.py
+++ b/pyobjc-framework-MediaPlayer/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MediaToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-MediaToolbox/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Message/pyobjc_setup.py
+++ b/pyobjc-framework-Message/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Metal/pyobjc_setup.py
+++ b/pyobjc-framework-Metal/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MetalKit/pyobjc_setup.py
+++ b/pyobjc-framework-MetalKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ModelIO/pyobjc_setup.py
+++ b/pyobjc-framework-ModelIO/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
+++ b/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
+++ b/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-NetFS/pyobjc_setup.py
+++ b/pyobjc-framework-NetFS/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Network/pyobjc_setup.py
+++ b/pyobjc-framework-Network/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-NetworkExtension/pyobjc_setup.py
+++ b/pyobjc-framework-NetworkExtension/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-NotificationCenter/pyobjc_setup.py
+++ b/pyobjc-framework-NotificationCenter/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-OSAKit/pyobjc_setup.py
+++ b/pyobjc-framework-OSAKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-OSLog/pyobjc_setup.py
+++ b/pyobjc-framework-OSLog/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-OpenDirectory/pyobjc_setup.py
+++ b/pyobjc-framework-OpenDirectory/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-PencilKit/pyobjc_setup.py
+++ b/pyobjc-framework-PencilKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Photos/pyobjc_setup.py
+++ b/pyobjc-framework-Photos/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-PhotosUI/pyobjc_setup.py
+++ b/pyobjc-framework-PhotosUI/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-PreferencePanes/pyobjc_setup.py
+++ b/pyobjc-framework-PreferencePanes/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-PubSub/pyobjc_setup.py
+++ b/pyobjc-framework-PubSub/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-PushKit/pyobjc_setup.py
+++ b/pyobjc-framework-PushKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-QTKit/pyobjc_setup.py
+++ b/pyobjc-framework-QTKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Quartz/pyobjc_setup.py
+++ b/pyobjc-framework-Quartz/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
+++ b/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SafariServices/pyobjc_setup.py
+++ b/pyobjc-framework-SafariServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SceneKit/pyobjc_setup.py
+++ b/pyobjc-framework-SceneKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ScreenSaver/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenSaver/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
+++ b/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SearchKit/pyobjc_setup.py
+++ b/pyobjc-framework-SearchKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Security/pyobjc_setup.py
+++ b/pyobjc-framework-Security/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SecurityInterface/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityInterface/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ServerNotification/pyobjc_setup.py
+++ b/pyobjc-framework-ServerNotification/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-ServiceManagement/pyobjc_setup.py
+++ b/pyobjc-framework-ServiceManagement/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Social/pyobjc_setup.py
+++ b/pyobjc-framework-Social/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
+++ b/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Speech/pyobjc_setup.py
+++ b/pyobjc-framework-Speech/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SpriteKit/pyobjc_setup.py
+++ b/pyobjc-framework-SpriteKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-StoreKit/pyobjc_setup.py
+++ b/pyobjc-framework-StoreKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SyncServices/pyobjc_setup.py
+++ b/pyobjc-framework-SyncServices/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-SystemExtensions/pyobjc_setup.py
+++ b/pyobjc-framework-SystemExtensions/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-UserNotifications/pyobjc_setup.py
+++ b/pyobjc-framework-UserNotifications/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
+++ b/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-VideoToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-VideoToolbox/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-Vision/pyobjc_setup.py
+++ b/pyobjc-framework-Vision/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-WebKit/pyobjc_setup.py
+++ b/pyobjc-framework-WebKit/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-XgridFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-XgridFoundation/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")

--- a/pyobjc-framework-libdispatch/pyobjc_setup.py
+++ b/pyobjc-framework-libdispatch/pyobjc_setup.py
@@ -229,6 +229,10 @@ def get_sdk_level():
     if sdk == "/":
         return get_os_level()
 
+    # Remove trailing slashes to prevent basename returning "" incorrectly.
+    # Without this "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
+    # will fail the below assertions.
+    sdk = sdk.rstrip("/")
     sdkname = os.path.basename(sdk)
     assert sdkname.startswith("MacOSX")
     assert sdkname.endswith(".sdk")


### PR DESCRIPTION
Currently if `get_sdk()` finds a path such as `/path/to/MacOSX10.6.sdk/`, then `os.path.basename` will return empty-string and `get_sdk_level()` will fail an assertion, breaking the build incorrectly.

This changes the logic to remove all trailing slashes from the sdk path.