### PR TITLE
fix bug #337, _dyld_shared_cache_contains_path fails on <= 10.15

### DIFF
--- a/pyobjc-core/Lib/objc/_dyld.py
+++ b/pyobjc-core/Lib/objc/_dyld.py
@@ -19,6 +19,14 @@ try:
 except ImportError:
     _dyld_shared_cache_contains_path = None
 
+def dyld_shared_cache_contains_path(p):
+    if _dyld_shared_cache_contains_path is None:
+        return False
+    try:
+        return _dyld_shared_cache_contains_path(p)
+    except NotImplementedError:
+        return False
+
 # These are the defaults as per man dyld(1)
 #
 DEFAULT_FRAMEWORK_FALLBACK = ":".join(
@@ -97,9 +105,8 @@ def dyld_framework(filename, framework_name, version=None):
                 yield os.path.join(path, framework_name + ".framework", framework_name)
 
     for f in inject_suffixes(_search()):
-        if _dyld_shared_cache_contains_path is not None:
-            if _dyld_shared_cache_contains_path(f):
-                return f
+        if dyld_shared_cache_contains_path(f):
+            return f
 
         if os.path.exists(f):
             return f
@@ -125,9 +132,8 @@ def dyld_library(filename, libname):
             yield os.path.join(path, libname)
 
     for f in inject_suffixes(_search()):
-        if _dyld_shared_cache_contains_path is not None:
-            if _dyld_shared_cache_contains_path(f):
-                return f
+        if dyld_shared_cache_contains_path(f):
+            return f
         if os.path.exists(f):
             return f
     raise ValueError("dylib %s could not be found" % (filename,))


### PR DESCRIPTION
fixes  [337](https://github.com/ronaldoussoren/pyobjc/issues/337) 

on Mac OS <= 10.15, pyobjc fails to load any frameworks:

```
>>> import Foundation
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/local/Library/Python/3.7/lib/python/site-packages/Foundation/__init__.py", line 9, in <module>
    import CoreFoundation
  File "/Users/local/Library/Python/3.7/lib/python/site-packages/CoreFoundation/__init__.py", line 16, in <module>
    objc.pathForFramework("/System/Library/Frameworks/CoreFoundation.framework"),
  File "/Users/local/Library/Python/3.7/lib/python/site-packages/objc/_dyld.py", line 148, in pathForFramework
    fpath, name, version = infoForFramework(dyld_find(path))
  File "/Users/local/Library/Python/3.7/lib/python/site-packages/objc/_dyld.py", line 142, in dyld_find
    return dyld_framework(filename, framework_name, version)
  File "/Users/local/Library/Python/3.7/lib/python/site-packages/objc/_dyld.py", line 101, in dyld_framework
    if _dyld_shared_cache_contains_path(f):
NotImplementedError: _dyld_shared_cache_contains_path not available
```