### PR TITLE
Switch from bzero to memset

### DIFF
--- a/pyobjc-framework-Cocoa/Modules/_AppKit_nsbitmap.m
+++ b/pyobjc-framework-Cocoa/Modules/_AppKit_nsbitmap.m
@@ -101,8 +101,8 @@ call_NSBitmapImageRep_initWithBitmap(PyObject* method, PyObject* self,
         }
 
         PyErr_Clear();
-        bzero(dataPlanes, sizeof(dataPlanes));
-        bzero(py_Planes, sizeof(py_Planes));
+        memset(dataPlanes, 0, sizeof(dataPlanes));
+        memset(py_Planes, 0, sizeof(py_Planes));
 
         if (!PyArg_ParseTuple(arguments, "Oiiiibbsii", &maybeNone, &width, &height, &bps,
                               &spp, &hasAlpha, &isPlanar, &colorSpaceName, &bpr, &bpp)) {
@@ -212,8 +212,8 @@ call_NSBitmapImageRep_initWithBitmapFormat(PyObject* method, PyObject* self,
         }
 
         PyErr_Clear();
-        bzero(dataPlanes, sizeof(dataPlanes));
-        bzero(py_Planes, sizeof(py_Planes));
+        memset(dataPlanes, 0, sizeof(dataPlanes));
+        memset(py_Planes, 0, sizeof(py_Planes));
 
         if (!PyArg_ParseTuple(arguments, "Oiiiibbsiii", &maybeNone, &width, &height, &bps,
                               &spp, &hasAlpha, &isPlanar, &colorSpaceName, &format, &bpr,


### PR DESCRIPTION
Switch from using bzero to memset to address installation issue on macOS 11 on AS mac.

Versions/3.8/Headers -arch arm64e -arch x86_64 -I/Users/danielkim/.swe/include -I/AppleInternal/Library/Frameworks/Python.framework/Versions/3.8/include/python3.8 -c Modules/_AppKit.m -o build/temp.macosx-10.15-arm64-3.8/Modules/_AppKit.o -Wno-deprecated-declarations -isysroot /Applications/Xcode-customer.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk -DPyObjC_BUILD_RELEASE=1100 -Werror
    In file included from Modules/_AppKit.m:14:
    Modules/_AppKit_nsbitmap.m:104:9: error: implicitly declaring library function 'bzero' with type 'void (void *, unsigned long)' [-Werror,-Wimplicit-function-declaration]
            bzero(dataPlanes, sizeof(dataPlanes));
            ^
    Modules/_AppKit_nsbitmap.m:104:9: note: include the header <strings.h> or explicitly provide a declaration for 'bzero'
    1 error generated.
    error: command 'clang' failed with exit status 1