### PR TITLE
Fix setup error by slicing the first two version integers from the version list.

### DIFF
--- a/pyobjc-core/setup.py
+++ b/pyobjc-core/setup.py
@@ -552,11 +552,11 @@ class oc_build_ext(build_ext.build_ext):
 
         CFLAGS.append(
             "-DPyObjC_BUILD_RELEASE=%02d%02d"
-            % (tuple(map(int, get_sdk_level(self.sdk_root).split("."))))
+            % (tuple(map(int, get_sdk_level(self.sdk_root).split(".")[:2])))
         )
         EXT_CFLAGS.append(
             "-DPyObjC_BUILD_RELEASE=%02d%02d"
-            % (tuple(map(int, get_sdk_level(self.sdk_root).split("."))))
+            % (tuple(map(int, get_sdk_level(self.sdk_root).split(".")[:2])))
         )
 
         _fixup_compiler(use_ccache=any(cmd in sys.argv for cmd in ["develop", "test"]))

--- a/pyobjc-framework-AVFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-AVFoundation/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AVKit/pyobjc_setup.py
+++ b/pyobjc-framework-AVKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Accessibility/pyobjc_setup.py
+++ b/pyobjc-framework-Accessibility/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Accounts/pyobjc_setup.py
+++ b/pyobjc-framework-Accounts/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AdServices/pyobjc_setup.py
+++ b/pyobjc-framework-AdServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AdSupport/pyobjc_setup.py
+++ b/pyobjc-framework-AdSupport/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AddressBook/pyobjc_setup.py
+++ b/pyobjc-framework-AddressBook/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
+++ b/pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ApplicationServices/pyobjc_setup.py
+++ b/pyobjc-framework-ApplicationServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
+++ b/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Automator/pyobjc_setup.py
+++ b/pyobjc-framework-Automator/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-BusinessChat/pyobjc_setup.py
+++ b/pyobjc-framework-BusinessChat/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CFNetwork/pyobjc_setup.py
+++ b/pyobjc-framework-CFNetwork/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CalendarStore/pyobjc_setup.py
+++ b/pyobjc-framework-CalendarStore/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CallKit/pyobjc_setup.py
+++ b/pyobjc-framework-CallKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ClassKit/pyobjc_setup.py
+++ b/pyobjc-framework-ClassKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CloudKit/pyobjc_setup.py
+++ b/pyobjc-framework-CloudKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Cocoa/pyobjc_setup.py
+++ b/pyobjc-framework-Cocoa/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Collaboration/pyobjc_setup.py
+++ b/pyobjc-framework-Collaboration/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ColorSync/pyobjc_setup.py
+++ b/pyobjc-framework-ColorSync/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Contacts/pyobjc_setup.py
+++ b/pyobjc-framework-Contacts/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ContactsUI/pyobjc_setup.py
+++ b/pyobjc-framework-ContactsUI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreAudio/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudio/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
+++ b/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreData/pyobjc_setup.py
+++ b/pyobjc-framework-CoreData/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreHaptics/pyobjc_setup.py
+++ b/pyobjc-framework-CoreHaptics/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreLocation/pyobjc_setup.py
+++ b/pyobjc-framework-CoreLocation/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreMIDI/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMIDI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreML/pyobjc_setup.py
+++ b/pyobjc-framework-CoreML/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreMedia/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMedia/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreMotion/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMotion/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreServices/pyobjc_setup.py
+++ b/pyobjc-framework-CoreServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
+++ b/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreText/pyobjc_setup.py
+++ b/pyobjc-framework-CoreText/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CoreWLAN/pyobjc_setup.py
+++ b/pyobjc-framework-CoreWLAN/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
+++ b/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DVDPlayback/pyobjc_setup.py
+++ b/pyobjc-framework-DVDPlayback/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DeviceCheck/pyobjc_setup.py
+++ b/pyobjc-framework-DeviceCheck/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DictionaryServices/pyobjc_setup.py
+++ b/pyobjc-framework-DictionaryServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DiscRecording/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecording/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-DiskArbitration/pyobjc_setup.py
+++ b/pyobjc-framework-DiskArbitration/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-EventKit/pyobjc_setup.py
+++ b/pyobjc-framework-EventKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
+++ b/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
+++ b/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
+++ b/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-FSEvents/pyobjc_setup.py
+++ b/pyobjc-framework-FSEvents/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-FileProvider/pyobjc_setup.py
+++ b/pyobjc-framework-FileProvider/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-FileProviderUI/pyobjc_setup.py
+++ b/pyobjc-framework-FileProviderUI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-FinderSync/pyobjc_setup.py
+++ b/pyobjc-framework-FinderSync/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-GameCenter/pyobjc_setup.py
+++ b/pyobjc-framework-GameCenter/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-GameController/pyobjc_setup.py
+++ b/pyobjc-framework-GameController/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-GameKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-GameplayKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameplayKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
+++ b/pyobjc-framework-IMServicePlugIn/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-IOSurface/pyobjc_setup.py
+++ b/pyobjc-framework-IOSurface/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
+++ b/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-InputMethodKit/pyobjc_setup.py
+++ b/pyobjc-framework-InputMethodKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
+++ b/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-InstantMessage/pyobjc_setup.py
+++ b/pyobjc-framework-InstantMessage/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Intents/pyobjc_setup.py
+++ b/pyobjc-framework-Intents/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
+++ b/pyobjc-framework-InterfaceBuilderKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-KernelManagement/pyobjc_setup.py
+++ b/pyobjc-framework-KernelManagement/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
+++ b/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-LaunchServices/pyobjc_setup.py
+++ b/pyobjc-framework-LaunchServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-LinkPresentation/pyobjc_setup.py
+++ b/pyobjc-framework-LinkPresentation/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
+++ b/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MLCompute/pyobjc_setup.py
+++ b/pyobjc-framework-MLCompute/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MapKit/pyobjc_setup.py
+++ b/pyobjc-framework-MapKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
+++ b/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MediaLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-MediaLibrary/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MediaPlayer/pyobjc_setup.py
+++ b/pyobjc-framework-MediaPlayer/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MediaToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-MediaToolbox/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Message/pyobjc_setup.py
+++ b/pyobjc-framework-Message/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Metal/pyobjc_setup.py
+++ b/pyobjc-framework-Metal/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MetalKit/pyobjc_setup.py
+++ b/pyobjc-framework-MetalKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
+++ b/pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
+++ b/pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ModelIO/pyobjc_setup.py
+++ b/pyobjc-framework-ModelIO/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
+++ b/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
+++ b/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-NetFS/pyobjc_setup.py
+++ b/pyobjc-framework-NetFS/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Network/pyobjc_setup.py
+++ b/pyobjc-framework-Network/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-NetworkExtension/pyobjc_setup.py
+++ b/pyobjc-framework-NetworkExtension/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-NotificationCenter/pyobjc_setup.py
+++ b/pyobjc-framework-NotificationCenter/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-OSAKit/pyobjc_setup.py
+++ b/pyobjc-framework-OSAKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-OSLog/pyobjc_setup.py
+++ b/pyobjc-framework-OSLog/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-OpenDirectory/pyobjc_setup.py
+++ b/pyobjc-framework-OpenDirectory/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PassKit/pyobjc_setup.py
+++ b/pyobjc-framework-PassKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PencilKit/pyobjc_setup.py
+++ b/pyobjc-framework-PencilKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Photos/pyobjc_setup.py
+++ b/pyobjc-framework-Photos/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PhotosUI/pyobjc_setup.py
+++ b/pyobjc-framework-PhotosUI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PreferencePanes/pyobjc_setup.py
+++ b/pyobjc-framework-PreferencePanes/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PubSub/pyobjc_setup.py
+++ b/pyobjc-framework-PubSub/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-PushKit/pyobjc_setup.py
+++ b/pyobjc-framework-PushKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Quartz/pyobjc_setup.py
+++ b/pyobjc-framework-Quartz/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
+++ b/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ReplayKit/pyobjc_setup.py
+++ b/pyobjc-framework-ReplayKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SafariServices/pyobjc_setup.py
+++ b/pyobjc-framework-SafariServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SceneKit/pyobjc_setup.py
+++ b/pyobjc-framework-SceneKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ScreenSaver/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenSaver/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ScreenTime/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenTime/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
+++ b/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SearchKit/pyobjc_setup.py
+++ b/pyobjc-framework-SearchKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Security/pyobjc_setup.py
+++ b/pyobjc-framework-Security/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SecurityInterface/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityInterface/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ServerNotification/pyobjc_setup.py
+++ b/pyobjc-framework-ServerNotification/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-ServiceManagement/pyobjc_setup.py
+++ b/pyobjc-framework-ServiceManagement/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Social/pyobjc_setup.py
+++ b/pyobjc-framework-Social/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
+++ b/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Speech/pyobjc_setup.py
+++ b/pyobjc-framework-Speech/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SpriteKit/pyobjc_setup.py
+++ b/pyobjc-framework-SpriteKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-StoreKit/pyobjc_setup.py
+++ b/pyobjc-framework-StoreKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SyncServices/pyobjc_setup.py
+++ b/pyobjc-framework-SyncServices/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-SystemExtensions/pyobjc_setup.py
+++ b/pyobjc-framework-SystemExtensions/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
+++ b/pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-UserNotifications/pyobjc_setup.py
+++ b/pyobjc-framework-UserNotifications/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
+++ b/pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
+++ b/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-VideoToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-VideoToolbox/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Virtualization/pyobjc_setup.py
+++ b/pyobjc-framework-Virtualization/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-Vision/pyobjc_setup.py
+++ b/pyobjc-framework-Vision/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-WebKit/pyobjc_setup.py
+++ b/pyobjc-framework-WebKit/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":

--- a/pyobjc-framework-libdispatch/pyobjc_setup.py
+++ b/pyobjc-framework-libdispatch/pyobjc_setup.py
@@ -446,17 +446,17 @@ def Extension(*args, **kwds):
             cflags.append(data)
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, version.split("."))))
+                % (tuple(map(int, version.split(".")[:2])))
             )
         else:
             cflags.append(
                 "-DPyObjC_BUILD_RELEASE=%02d%02d"
-                % (tuple(map(int, os_level.split("."))))
+                % (tuple(map(int, os_level.split(".")[:2])))
             )
 
     else:
         cflags.append(
-            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split("."))))
+            "-DPyObjC_BUILD_RELEASE=%02d%02d" % (tuple(map(int, os_level.split(".")[:2])))
         )
 
     if os_level == "10.4":


### PR DESCRIPTION
On MacOS 11.4 with Xcode 13 beta 1, the version in the *.plist file will be "10.15.4".
It results in the string formatting error.
This changes take the first two version integers to resolve the formatting error.