### PR TITLE
Fix two doc typos

### DIFF
--- a/docs/api/module-objc.rst
+++ b/docs/api/module-objc.rst
@@ -610,7 +610,7 @@ Types
    The *cobject* and *c_void_p* arguments should always be passed as keyword arguments,
    and at most one of them should be provided. This will construct a proxy object of the
    right subclass of :class:`objc_object` for the Cocoa object that the passed in value
-   refers to. *Cobject* should be a Pytho capsule created using the :meth:`__cobject__`
+   refers to. *Cobject* should be a Python capsule created using the :meth:`__cobject__`
    method, *c_void_p* should be a :class:`ctypes.c_void_p`.
 
    .. note::
@@ -631,7 +631,7 @@ Types
       Read-only property that provides explicit access to just the instance methods
       of an object.
 
-   .. data:: \__block_signature__
+   .. data:: __block_signature__
 
       Property with the type signature for calling a block, or :data:`None`.
 


### PR DESCRIPTION
From here: [objc – The PyObjC bridge — PyObjC - the Python to Objective-C bridge](https://pyobjc.readthedocs.io/en/latest/api/module-objc.html#objc.objc_object)

Before:

![image](https://user-images.githubusercontent.com/625793/186180871-5e13c2c3-4ee7-47f1-ae36-f6b45b8d3034.png)

After:

![image](https://user-images.githubusercontent.com/625793/186181745-8b5aca9a-3362-4770-8a53-718444c470b9.png)
