### PR TITLE
fix for no Frameworks loaded when using pyobjc and python2 on a modern system

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@ What's new in PyObjC
 
 An overview of the relevant changes in new, and older, releases.
 
+Version 5.3a1
+-------------
+
+* #309: Fix incompatibility with macOS 11 in framework loader
+
 Version 5.3
 -----------
 

--- a/pyobjc-core/Lib/objc/_dyld.py
+++ b/pyobjc-core/Lib/objc/_dyld.py
@@ -119,5 +119,9 @@ def dyld_find(filename):
         return dyld_library(filename, os.path.basename(filename))
 
 def pathForFramework(path):
+    if path.startswith("/System/"):
+        # On macOS 11 system frameworks are in a shared cache, not
+        # in the filesystem.
+        return path
     fpath, name, version = infoForFramework(dyld_find(path))
     return os.path.join(fpath, name + '.framework')

--- a/pyobjc-core/Modules/objc/pyobjc.h
+++ b/pyobjc-core/Modules/objc/pyobjc.h
@@ -5,7 +5,7 @@
  * Central include file for PyObjC.
  */
 
-#define OBJC_VERSION "5.3"
+#define OBJC_VERSION "5.3.1"
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>


### PR DESCRIPTION
When using pyobjc with python2 on osx13, I got the same `ImportError: Framework CoreServices could not be found` that was fixed in later versions.
Since `v5.3` was the last version that worked with python2, this PR just cherry-picks the fix from #309 onto that tag and bumps the version to v5.3.1
