### PR TITLE
fix pythonCollectionFromPropertyList fails on converting dates prior to year 1970

### DIFF
--- a/pyobjc-framework-Cocoa/Lib/PyObjCTools/Conversion.py
+++ b/pyobjc-framework-Cocoa/Lib/PyObjCTools/Conversion.py
@@ -217,7 +217,11 @@ def pythonCollectionFromPropertyList(aCollection, conversionHelper=None):
     elif isinstance(aCollection, Foundation.NSData):
         return bytes(aCollection)
     elif isinstance(aCollection, Foundation.NSDate):
-        return datetime.datetime.fromtimestamp(aCollection.timeIntervalSince1970())
+        timestamp = aCollection.timeIntervalSince1970()
+        if timestamp < 0:
+            return datetime.datetime.fromtimestamp(0) - datetime.timedelta(seconds=-timestamp)
+        else:
+            return datetime.datetime.fromtimestamp(timestamp)
     elif isinstance(aCollection, (objc.pyobjc_unicode, Foundation.NSString)):
         return str(aCollection)
     elif isinstance(aCollection, OC_PythonLong):

--- a/pyobjc-framework-Cocoa/PyObjCTest/test_conversion.py
+++ b/pyobjc-framework-Cocoa/PyObjCTest/test_conversion.py
@@ -186,6 +186,13 @@ class TestConversion(TestCase):
             v = Conversion.pythonCollectionFromPropertyList(value)
             self.assertIsInstance(v, datetime.datetime)
 
+        with self.subTest("date prior year 1970"):
+            value = Cocoa.NSDate.dateWithTimeIntervalSince1970_(-10000000000)
+            self.assertIsInstance(value, Cocoa.NSDate)
+
+            v = Conversion.pythonCollectionFromPropertyList(value)
+            self.assertIsInstance(v, datetime.datetime)
+
         with self.subTest("decimal"):
             value = Cocoa.NSDecimalNumber.decimalNumberWithString_("42.5")
             self.assertIsInstance(value, Cocoa.NSDecimalNumber)


### PR DESCRIPTION
Fixes a issue where `pythonCollectionFromPropertyList` crashes on dates prior to year 1970.

Both `NSDate` and python's `datetime` classes are capable of handling dates prior to 1970/01/01. However, the `datetime.fromtimestamp` API does not. It would throw the following exception:

```
  File "/opt/homebrew/lib/python3.11/site-packages/PyObjCTools/Conversion.py", line 220, in pythonCollectionFromPropertyList
    return datetime.datetime.fromtimestamp(aCollection.timeIntervalSince1970())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: year 0 is out of range
```