### PR TITLE
Add assertions to verify PyObjCObject flags and the block_literal reserved field.

### DIFF
--- a/pyobjc-core/Modules/objc/block_support.m
+++ b/pyobjc-core/Modules/objc/block_support.m
@@ -59,6 +59,8 @@ const char* _Nullable PyObjCBlock_GetSignature(void* _block)
 {
     struct block_literal* block = (struct block_literal*)_block;
 
+    PyObjC_Assert(block->reserved == 0, NULL);
+
     if (((intptr_t)(block->isa)) & 0x1) {
         /* XXX: Hack to avoid a hard crash that I haven't been able
          * to pintpoint yet (test doesn't fail reliably, and I haven't

--- a/pyobjc-core/Modules/objc/objc-object.h
+++ b/pyobjc-core/Modules/objc/objc-object.h
@@ -11,6 +11,16 @@ NS_ASSUME_NONNULL_BEGIN
 #define PyObjCObject_kCFOBJECT 0x20
 #define PyObjCObject_kBLOCK 0x40
 #define PyObjCObject_kNEW_WRAPPER 0x80
+#define PyObjCObject_kALL_FLAGS             \
+   ( PyObjCObject_kDEFAULT                  \
+   | PyObjCObject_kUNINITIALIZED            \
+   | PyObjCObject_kDEALLOC_HELPER           \
+   | PyObjCObject_kSHOULD_NOT_RELEASE       \
+   | PyObjCObject_kMAGIC_COOKIE             \
+   | PyObjCObject_kCFOBJECT                 \
+   | PyObjCObject_kBLOCK                    \
+   | PyObjCObject_kNEW_WRAPPER              \
+   )
 
 typedef struct {
     PyObject_HEAD
@@ -38,7 +48,12 @@ void PyObjCObject_ClearObject(PyObject* object);
 void _PyObjCObject_FreeDeallocHelper(PyObject* obj);
 PyObject* _Nullable _PyObjCObject_NewDeallocHelper(id objc_object);
 
-#define PyObjCObject_GetFlags(object) (((PyObjCObject*)(object))->flags)
+static inline unsigned int PyObjCObject_GetFlags(void *object)
+{
+    unsigned int flags = ((PyObjCObject*)(object))->flags;
+    PyObjC_Assert((flags & ~PyObjCObject_kALL_FLAGS) == 0, flags);
+    return flags;
+}
 #define PyObjCObject_IsBlock(object) (PyObjCObject_GetFlags(object) & PyObjCObject_kBLOCK)
 #define PyObjCObject_IsMagic(object)                                                     \
     (PyObjCObject_GetFlags(object) & PyObjCObject_kMAGIC_COOKIE)


### PR DESCRIPTION
Should help to detect ref counting issues like #594.