### PR TITLE
Fix sw_vers flag capitalization

### DIFF
--- a/disabled-pyobjc-framework-FSKit/pyobjc_setup.py
+++ b/disabled-pyobjc-framework-FSKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-core/Tools/pyobjc_setup.py
+++ b/pyobjc-core/Tools/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-core/setup.py
+++ b/pyobjc-core/setup.py
@@ -381,10 +381,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AVFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-AVFoundation/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AVKit/pyobjc_setup.py
+++ b/pyobjc-framework-AVKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AVRouting/pyobjc_setup.py
+++ b/pyobjc-framework-AVRouting/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Accessibility/pyobjc_setup.py
+++ b/pyobjc-framework-Accessibility/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Accounts/pyobjc_setup.py
+++ b/pyobjc-framework-Accounts/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AdServices/pyobjc_setup.py
+++ b/pyobjc-framework-AdServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AdSupport/pyobjc_setup.py
+++ b/pyobjc-framework-AdSupport/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AddressBook/pyobjc_setup.py
+++ b/pyobjc-framework-AddressBook/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
+++ b/pyobjc-framework-AppTrackingTransparency/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
+++ b/pyobjc-framework-AppleScriptObjC/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ApplicationServices/pyobjc_setup.py
+++ b/pyobjc-framework-ApplicationServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AudioVideoBridging/pyobjc_setup.py
+++ b/pyobjc-framework-AudioVideoBridging/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
+++ b/pyobjc-framework-AuthenticationServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-AutomaticAssessmentConfiguration/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Automator/pyobjc_setup.py
+++ b/pyobjc-framework-Automator/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-BackgroundAssets/pyobjc_setup.py
+++ b/pyobjc-framework-BackgroundAssets/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-BrowserEngineKit/pyobjc_setup.py
+++ b/pyobjc-framework-BrowserEngineKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-BusinessChat/pyobjc_setup.py
+++ b/pyobjc-framework-BusinessChat/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CFNetwork/pyobjc_setup.py
+++ b/pyobjc-framework-CFNetwork/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CalendarStore/pyobjc_setup.py
+++ b/pyobjc-framework-CalendarStore/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CallKit/pyobjc_setup.py
+++ b/pyobjc-framework-CallKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Carbon/pyobjc_setup.py
+++ b/pyobjc-framework-Carbon/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Cinematic/pyobjc_setup.py
+++ b/pyobjc-framework-Cinematic/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ClassKit/pyobjc_setup.py
+++ b/pyobjc-framework-ClassKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CloudKit/pyobjc_setup.py
+++ b/pyobjc-framework-CloudKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Cocoa/pyobjc_setup.py
+++ b/pyobjc-framework-Cocoa/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Collaboration/pyobjc_setup.py
+++ b/pyobjc-framework-Collaboration/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ColorSync/pyobjc_setup.py
+++ b/pyobjc-framework-ColorSync/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Contacts/pyobjc_setup.py
+++ b/pyobjc-framework-Contacts/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ContactsUI/pyobjc_setup.py
+++ b/pyobjc-framework-ContactsUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreAudio/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudio/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
+++ b/pyobjc-framework-CoreAudioKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
+++ b/pyobjc-framework-CoreBluetooth/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreData/pyobjc_setup.py
+++ b/pyobjc-framework-CoreData/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreHaptics/pyobjc_setup.py
+++ b/pyobjc-framework-CoreHaptics/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreLocation/pyobjc_setup.py
+++ b/pyobjc-framework-CoreLocation/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreMIDI/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMIDI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreML/pyobjc_setup.py
+++ b/pyobjc-framework-CoreML/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreMedia/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMedia/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMediaIO/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreMotion/pyobjc_setup.py
+++ b/pyobjc-framework-CoreMotion/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreServices/pyobjc_setup.py
+++ b/pyobjc-framework-CoreServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
+++ b/pyobjc-framework-CoreSpotlight/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreText/pyobjc_setup.py
+++ b/pyobjc-framework-CoreText/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CoreWLAN/pyobjc_setup.py
+++ b/pyobjc-framework-CoreWLAN/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
+++ b/pyobjc-framework-CryptoTokenKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DVDPlayback/pyobjc_setup.py
+++ b/pyobjc-framework-DVDPlayback/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DataDetection/pyobjc_setup.py
+++ b/pyobjc-framework-DataDetection/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DeviceCheck/pyobjc_setup.py
+++ b/pyobjc-framework-DeviceCheck/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DeviceDiscoveryExtension/pyobjc_setup.py
+++ b/pyobjc-framework-DeviceDiscoveryExtension/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DictionaryServices/pyobjc_setup.py
+++ b/pyobjc-framework-DictionaryServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DiscRecording/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecording/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
+++ b/pyobjc-framework-DiscRecordingUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-DiskArbitration/pyobjc_setup.py
+++ b/pyobjc-framework-DiskArbitration/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-EventKit/pyobjc_setup.py
+++ b/pyobjc-framework-EventKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
+++ b/pyobjc-framework-ExceptionHandling/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
+++ b/pyobjc-framework-ExecutionPolicy/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ExtensionKit/pyobjc_setup.py
+++ b/pyobjc-framework-ExtensionKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
+++ b/pyobjc-framework-ExternalAccessory/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-FSEvents/pyobjc_setup.py
+++ b/pyobjc-framework-FSEvents/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-FileProvider/pyobjc_setup.py
+++ b/pyobjc-framework-FileProvider/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-FileProviderUI/pyobjc_setup.py
+++ b/pyobjc-framework-FileProviderUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-FinderSync/pyobjc_setup.py
+++ b/pyobjc-framework-FinderSync/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-GameCenter/pyobjc_setup.py
+++ b/pyobjc-framework-GameCenter/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-GameController/pyobjc_setup.py
+++ b/pyobjc-framework-GameController/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-GameKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-GameplayKit/pyobjc_setup.py
+++ b/pyobjc-framework-GameplayKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-HealthKit/pyobjc_setup.py
+++ b/pyobjc-framework-HealthKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-IOBluetooth/pyobjc_setup.py
+++ b/pyobjc-framework-IOBluetooth/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-IOBluetoothUI/pyobjc_setup.py
+++ b/pyobjc-framework-IOBluetoothUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-IOSurface/pyobjc_setup.py
+++ b/pyobjc-framework-IOSurface/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
+++ b/pyobjc-framework-ImageCaptureCore/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-InputMethodKit/pyobjc_setup.py
+++ b/pyobjc-framework-InputMethodKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
+++ b/pyobjc-framework-InstallerPlugins/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-InstantMessage/pyobjc_setup.py
+++ b/pyobjc-framework-InstantMessage/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Intents/pyobjc_setup.py
+++ b/pyobjc-framework-Intents/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-IntentsUI/pyobjc_setup.py
+++ b/pyobjc-framework-IntentsUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-KernelManagement/pyobjc_setup.py
+++ b/pyobjc-framework-KernelManagement/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
+++ b/pyobjc-framework-LatentSemanticMapping/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-LaunchServices/pyobjc_setup.py
+++ b/pyobjc-framework-LaunchServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-LinkPresentation/pyobjc_setup.py
+++ b/pyobjc-framework-LinkPresentation/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
+++ b/pyobjc-framework-LocalAuthentication/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py
+++ b/pyobjc-framework-LocalAuthenticationEmbeddedUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MLCompute/pyobjc_setup.py
+++ b/pyobjc-framework-MLCompute/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MailKit/pyobjc_setup.py
+++ b/pyobjc-framework-MailKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MapKit/pyobjc_setup.py
+++ b/pyobjc-framework-MapKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
+++ b/pyobjc-framework-MediaAccessibility/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MediaExtension/pyobjc_setup.py
+++ b/pyobjc-framework-MediaExtension/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MediaLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-MediaLibrary/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MediaPlayer/pyobjc_setup.py
+++ b/pyobjc-framework-MediaPlayer/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MediaToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-MediaToolbox/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Metal/pyobjc_setup.py
+++ b/pyobjc-framework-Metal/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MetalFX/pyobjc_setup.py
+++ b/pyobjc-framework-MetalFX/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MetalKit/pyobjc_setup.py
+++ b/pyobjc-framework-MetalKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
+++ b/pyobjc-framework-MetalPerformanceShaders/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
+++ b/pyobjc-framework-MetalPerformanceShadersGraph/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MetricKit/pyobjc_setup.py
+++ b/pyobjc-framework-MetricKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ModelIO/pyobjc_setup.py
+++ b/pyobjc-framework-ModelIO/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
+++ b/pyobjc-framework-MultipeerConnectivity/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
+++ b/pyobjc-framework-NaturalLanguage/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-NetFS/pyobjc_setup.py
+++ b/pyobjc-framework-NetFS/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Network/pyobjc_setup.py
+++ b/pyobjc-framework-Network/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-NetworkExtension/pyobjc_setup.py
+++ b/pyobjc-framework-NetworkExtension/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-NotificationCenter/pyobjc_setup.py
+++ b/pyobjc-framework-NotificationCenter/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-OSAKit/pyobjc_setup.py
+++ b/pyobjc-framework-OSAKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-OSLog/pyobjc_setup.py
+++ b/pyobjc-framework-OSLog/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-OpenDirectory/pyobjc_setup.py
+++ b/pyobjc-framework-OpenDirectory/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PHASE/pyobjc_setup.py
+++ b/pyobjc-framework-PHASE/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PassKit/pyobjc_setup.py
+++ b/pyobjc-framework-PassKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PencilKit/pyobjc_setup.py
+++ b/pyobjc-framework-PencilKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Photos/pyobjc_setup.py
+++ b/pyobjc-framework-Photos/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PhotosUI/pyobjc_setup.py
+++ b/pyobjc-framework-PhotosUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PreferencePanes/pyobjc_setup.py
+++ b/pyobjc-framework-PreferencePanes/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PubSub/pyobjc_setup.py
+++ b/pyobjc-framework-PubSub/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-PushKit/pyobjc_setup.py
+++ b/pyobjc-framework-PushKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Quartz/pyobjc_setup.py
+++ b/pyobjc-framework-Quartz/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
+++ b/pyobjc-framework-QuickLookThumbnailing/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ReplayKit/pyobjc_setup.py
+++ b/pyobjc-framework-ReplayKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SafariServices/pyobjc_setup.py
+++ b/pyobjc-framework-SafariServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SafetyKit/pyobjc_setup.py
+++ b/pyobjc-framework-SafetyKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SceneKit/pyobjc_setup.py
+++ b/pyobjc-framework-SceneKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenCaptureKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ScreenSaver/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenSaver/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ScreenTime/pyobjc_setup.py
+++ b/pyobjc-framework-ScreenTime/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
+++ b/pyobjc-framework-ScriptingBridge/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SearchKit/pyobjc_setup.py
+++ b/pyobjc-framework-SearchKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Security/pyobjc_setup.py
+++ b/pyobjc-framework-Security/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityFoundation/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SecurityInterface/pyobjc_setup.py
+++ b/pyobjc-framework-SecurityInterface/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SensitiveContentAnalysis/pyobjc_setup.py
+++ b/pyobjc-framework-SensitiveContentAnalysis/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ServiceManagement/pyobjc_setup.py
+++ b/pyobjc-framework-ServiceManagement/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SharedWithYou/pyobjc_setup.py
+++ b/pyobjc-framework-SharedWithYou/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SharedWithYouCore/pyobjc_setup.py
+++ b/pyobjc-framework-SharedWithYouCore/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ShazamKit/pyobjc_setup.py
+++ b/pyobjc-framework-ShazamKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Social/pyobjc_setup.py
+++ b/pyobjc-framework-Social/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
+++ b/pyobjc-framework-SoundAnalysis/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Speech/pyobjc_setup.py
+++ b/pyobjc-framework-Speech/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SpriteKit/pyobjc_setup.py
+++ b/pyobjc-framework-SpriteKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-StoreKit/pyobjc_setup.py
+++ b/pyobjc-framework-StoreKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Symbols/pyobjc_setup.py
+++ b/pyobjc-framework-Symbols/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SyncServices/pyobjc_setup.py
+++ b/pyobjc-framework-SyncServices/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
+++ b/pyobjc-framework-SystemConfiguration/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-SystemExtensions/pyobjc_setup.py
+++ b/pyobjc-framework-SystemExtensions/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-ThreadNetwork/pyobjc_setup.py
+++ b/pyobjc-framework-ThreadNetwork/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
+++ b/pyobjc-framework-UniformTypeIdentifiers/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-UserNotifications/pyobjc_setup.py
+++ b/pyobjc-framework-UserNotifications/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
+++ b/pyobjc-framework-UserNotificationsUI/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
+++ b/pyobjc-framework-VideoSubscriberAccount/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-VideoToolbox/pyobjc_setup.py
+++ b/pyobjc-framework-VideoToolbox/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Virtualization/pyobjc_setup.py
+++ b/pyobjc-framework-Virtualization/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-Vision/pyobjc_setup.py
+++ b/pyobjc-framework-Vision/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-WebKit/pyobjc_setup.py
+++ b/pyobjc-framework-WebKit/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
+++ b/pyobjc-framework-iTunesLibrary/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-libdispatch/pyobjc_setup.py
+++ b/pyobjc-framework-libdispatch/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)

--- a/pyobjc-framework-libxpc/pyobjc_setup.py
+++ b/pyobjc-framework-libxpc/pyobjc_setup.py
@@ -88,10 +88,10 @@ class oc_egg_info(egg_info.egg_info):
 
     def write_build_info(self):
         macos_version = subprocess.check_output(
-            ["sw_vers", "-productversion"], text=True
+            ["sw_vers", "-productVersion"], text=True
         ).strip()
         macos_build = subprocess.check_output(
-            ["sw_vers", "-buildversion"], text=True
+            ["sw_vers", "-buildVersion"], text=True
         ).strip()
         clang_version = (
             subprocess.check_output(["clang", "--version"], text=True)


### PR DESCRIPTION
Technically sw_vers uses snake case capitalization on CLI arguments (https://ss64.com/mac/sw_vers.html), but this was only partially respected in pyobjc. This commit changes all remaining incorrect capitalizations to the correct flag capitalization. Some sw_vers implementations seem to care about this, eg the darwin.DarwinTools implementation in nixpkgs. Other implementations are more lenient.