### PR TITLE
Issue #661: Fix python_requires package metadata in `setup.cfg`

### DIFF
--- a/pyobjc-core/setup.cfg
+++ b/pyobjc-core/setup.cfg
@@ -45,7 +45,7 @@ classifiers =
   Topic :: Software Development :: User Interfaces
 zip-safe = 0
 keywords = Objective-C, Cocoa
-python_requires = >=3.8
+python_requires = >=3.10
 
 [oc_build_ext]
 ;; Use this to control the deployment


### PR DESCRIPTION
https://github.com/ronaldoussoren/pyobjc/issues/661#issuecomment-3475220092
> Thank you !
> 
> I notice from that commit, shouldn't this line also be updated for consistency ?
> 
> https://github.com/ronaldoussoren/pyobjc/blob/ec575ded3f8993de1146ad774c532f3348aaf158/pyobjc-core/setup.cfg#L48

I'm guessing this wasn't changed because searching for `3.9` didn't reveal this line.
