### PR TITLE
Drop the GIL when sending KVO notifications.

### DIFF
--- a/pyobjc-core/Modules/objc/objc-object.m
+++ b/pyobjc-core/Modules/objc/objc-object.m
@@ -768,11 +768,13 @@ object_setattro(PyObject* obj, PyObject* name, PyObject* _Nullable value)
                 // LCOV_EXCL_STOP
             }
 
+            Py_BEGIN_ALLOW_THREADS
             @try {
                 [(NSObject*)obj_inst willChangeValueForKey:obj_name];
             } @catch (NSObject* localException) {
                 PyObjCErr_FromObjC(localException);
             }
+            Py_END_ALLOW_THREADS
             if (PyErr_Occurred()) {
                 return -1;
             }
@@ -842,11 +844,13 @@ object_setattro(PyObject* obj, PyObject* name, PyObject* _Nullable value)
 done:
     Py_CLEAR(descr);
     if (obj_inst && obj_name) {
+        Py_BEGIN_ALLOW_THREADS
         @try {
             [(NSObject*)obj_inst didChangeValueForKey:obj_name];
         } @catch (NSObject* localException) {
             PyObjCErr_FromObjC(localException);
         }
+        Py_END_ALLOW_THREADS
         if (PyErr_Occurred()) {
             res = -1;
         }


### PR DESCRIPTION
Otherwise if the notification handler calls back into pyobjc, it will deadlock.