### PR TITLE
Fix reference leak in NSData memory views

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,10 @@ Version 12.2.3
   value with a +1 retain count, but PyObjC's metadata did not reflect this
   and that results in memory leaks.
 
+* Fix a reference leak when calling ``NSData.bytes()`` or
+  ``NSMutableData.mutableBytes()``. Repeatedly creating and discarding the
+  returned memory views no longer keeps the data objects alive.
+
 Version 12.2.2
 --------------
 

--- a/pyobjc-core/Modules/objc/helpers-foundation-nsdata.m
+++ b/pyobjc-core/Modules/objc/helpers-foundation-nsdata.m
@@ -8,9 +8,7 @@ static PyObject* _Nullable call_NSData_bytes(PyObject* method, PyObject* self,
                                              size_t nargs)
 {
     const void*       bytes;
-    NSUInteger        bytes_len;
     struct objc_super super;
-    Py_buffer         info;
 
     if (PyObjC_CheckArgCount(method, 0, 0, nargs) == -1)
         return NULL;
@@ -21,13 +19,10 @@ static PyObject* _Nullable call_NSData_bytes(PyObject* method, PyObject* self,
             super.receiver    = PyObjCObject_GetObject(self);
             bytes             = ((void* (*)(struct objc_super*, SEL))objc_msgSendSuper)(
                 &super, PyObjCSelector_GetSelector(method));
-            bytes_len = ((NSUInteger (*)(struct objc_super*, SEL))objc_msgSendSuper)(
-                &super, @selector(length));
 
         } @catch (NSObject* localException) {
             PyObjCErr_FromObjC(localException);
-            bytes     = NULL;
-            bytes_len = 0;
+            bytes = NULL;
         }
     Py_END_ALLOW_THREADS
 
@@ -42,12 +37,14 @@ static PyObject* _Nullable call_NSData_bytes(PyObject* method, PyObject* self,
         return PyBytes_FromStringAndSize("", 0);
     }
 
-    if (unlikely(PyBuffer_FillInfo( // LCOV_BR_EXCL_LINE
-                     &info, self, (void*)bytes, bytes_len, 1, PyBUF_FULL_RO)
-                 < 0)) {
-        return NULL; // LCOV_EXCL_LINE
+    PyObject* result = PyMemoryView_FromObject(self);
+    if (unlikely(result == NULL)) { // LCOV_BR_EXCL_LINE
+        return NULL;                // LCOV_EXCL_LINE
     }
-    return PyMemoryView_FromBuffer(&info);
+
+    PyObject* readonly = PyObject_CallMethod(result, "toreadonly", NULL);
+    Py_DECREF(result);
+    return readonly;
 }
 
 static IMP
@@ -104,10 +101,7 @@ static PyObject* _Nullable call_NSMutableData_mutableBytes(PyObject*        meth
                                                            size_t nargs)
 {
     void*             bytes;
-    NSUInteger        bytes_len;
-    PyObject*         result;
     struct objc_super super;
-    Py_buffer         info;
 
     if (PyObjC_CheckArgCount(method, 0, 0, nargs) == -1)
         return NULL;
@@ -119,14 +113,10 @@ static PyObject* _Nullable call_NSMutableData_mutableBytes(PyObject*        meth
 
             bytes = ((void* (*)(struct objc_super*, SEL))objc_msgSendSuper)(
                 &super, PyObjCSelector_GetSelector(method));
-            bytes_len = ((NSUInteger (*)(struct objc_super*, SEL))objc_msgSendSuper)(
-                &super, @selector(length));
 
         } @catch (NSObject* localException) {
             PyObjCErr_FromObjC(localException);
-            result    = NULL;
-            bytes     = NULL;
-            bytes_len = 0;
+            bytes = NULL;
         }
     Py_END_ALLOW_THREADS
 
@@ -145,14 +135,7 @@ static PyObject* _Nullable call_NSMutableData_mutableBytes(PyObject*        meth
         return PyMemoryView_FromMemory("", 0, PyBUF_WRITE);
     }
 
-    if (unlikely(PyBuffer_FillInfo( // LCOV_BR_EXCL_LINE
-                     &info, self, bytes, bytes_len, 0, PyBUF_FULL)
-                 < 0)) {
-        return NULL; // LCOV_EXCL_LINE
-    }
-    result = PyMemoryView_FromBuffer(&info);
-
-    return result;
+    return PyMemoryView_FromObject(self);
 }
 
 static IMP

--- a/pyobjc-core/Modules/objc/python-api-used.h
+++ b/pyobjc-core/Modules/objc/python-api-used.h
@@ -201,6 +201,8 @@ PyAPI_FUNC(int) PyMember_SetOne(char*, struct PyMemberDef*, PyObject*)
     __attribute__((warn_unused_result));
 PyAPI_FUNC(PyObject* _Nullable) PyMemoryView_FromBuffer(const Py_buffer* info)
     __attribute__((warn_unused_result));
+PyAPI_FUNC(PyObject* _Nullable) PyMemoryView_FromObject(PyObject* base)
+    __attribute__((warn_unused_result));
 PyAPI_FUNC(PyObject* _Nullable) PyMethod_Function(PyObject*)
     __attribute__((warn_unused_result));
 PyAPI_FUNC(PyObject* _Nullable) PyMethod_Self(PyObject*)

--- a/pyobjc-core/PyObjCTest/test_nsdata.py
+++ b/pyobjc-core/PyObjCTest/test_nsdata.py
@@ -31,6 +31,17 @@ class TestNSDataSupport(TestCase):
         view = memoryview(buf)
         self.assertEqual(bytes(view), buf.bytes())
         self.assertTrue(view.readonly)
+        del view
+
+        refcount = sys.getrefcount(buf)
+        for _ in range(10):
+            view = buf.bytes()
+            del view
+        self.assertEqual(sys.getrefcount(buf), refcount)
+
+        view = buf.bytes()
+        del buf
+        self.assertEqual(bytes(view), b"hello")
 
     def testyRwBuffer(self):
         buf = NSMutableData.alloc().init()
@@ -47,6 +58,7 @@ class TestNSDataSupport(TestCase):
 
         self.assertEqual(buf.bytes(), b"Hello")
         self.assertIsInstance(buf.bytes(), memoryview)
+        self.assertTrue(buf.bytes().readonly)
 
         self.assertEqual(buf[0:2], b"He")
         buf[0:2] = b"hE"
@@ -66,6 +78,19 @@ class TestNSDataSupport(TestCase):
         view = memoryview(buf)
         self.assertEqual(bytes(view), buf.bytes())
         self.assertFalse(view.readonly)
+        del view
+
+        refcount = sys.getrefcount(buf)
+        for _ in range(10):
+            view = buf.mutableBytes()
+            del view
+        self.assertEqual(sys.getrefcount(buf), refcount)
+
+        del vw
+        view = buf.mutableBytes()
+        del buf
+        view[0:1] = b"Z"
+        self.assertEqual(bytes(view), b"ZEllo")
 
     def testNullHandling(self):
         nullBuffer = OC_MutableDataHelper.alloc().initWithScenario_(0)


### PR DESCRIPTION

## Context

Hello! I came across this while investigating what appeared to be a memory leak in a long-running [Bleak](https://github.com/hbldh/bleak) CoreBluetooth scanner used by [Theengs Gateway](https://github.com/theengs/gateway).

Native heap snapshots showed the number of `NSData` instances increasing linearly with received advertisements. A minimal reproducer then isolated the growth to PyObjC's `NSData.bytes()` mapping. The corresponding scanner changes are in [hbldh/bleak#2020](https://github.com/hbldh/bleak/pull/2020).

## Summary

`NSData.bytes()` and `NSMutableData.mutableBytes()` leaked one exporter reference per returned memory view. This change uses the exporter's managed buffer protocol, so the view keeps the data alive while needed and releases it afterwards.

The public behavior remains unchanged: `NSData.bytes()` is still read-only, even for an `NSMutableData` receiver, while `mutableBytes()` remains writable.

## Cause and fix

Before this change, the method mappings used `PyBuffer_FillInfo()` to populate a `Py_buffer` with `self` as its exporter. This increments `self`'s reference count, but `PyMemoryView_FromBuffer()` does not take ownership of and release that reference. As a result, every discarded view left its NSData proxy and native object alive.

The fix uses `PyMemoryView_FromObject(self)` instead, which acquires the exported buffer through the managed buffer protocol. `bytes()` derives a read-only view from it, while `mutableBytes()` returns the writable view directly.

## Minimal reproduction

```python
import objc
import sys

NSData = objc.lookUpClass("NSData")
data = NSData.dataWithData_(b"test")
initial = sys.getrefcount(data)

for _ in range(10):
    view = data.bytes()
    del view

assert sys.getrefcount(data) == initial
```

On PyObjC 12.2.2, the final refcount is `initial + 10`. The same problem affects `NSMutableData.mutableBytes()`.

## Checks

- 100,000 calls per affected API with stable refcounts
- mutability and view lifetime after deleting the original Python variable
- all 93 `PyObjCTest.test_nsdata` tests pass (2 version-gated skips)
- focused pre-commit checks, including clang-format and the Python C-API checker

Disclosure: I used OpenAI Codex extensively to investigate and implement this fix. I carefully reviewed and tested the changes, reproduced the behavior described above, and take responsibility for the contribution.
